### PR TITLE
RedHat Network fixes and documentation

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -7,26 +7,37 @@ This module creates and synchronizes rpm based repositories by managing mrepo.
 Install and configure a basic mrepo installation
 
     node default {
-      class { "mrepo": }
+      class { 'mrepo': }
     }
 
 Override default values and enable redhat network support for use in other classes
 
-    class { "mrepo::params":
+    class { 'mrepo::params':
       selinux       => true,
       rhn           => true,
-      rhn_username  => "user",
-      rhn_password  => "pass",
+      rhn_username  => 'user',
+      rhn_password  => 'pass',
     }
+
+Or using Hiera for parameters (same example)
+
+  code:
+    class { 'mrepo': }
+
+  Hiera:
+    mrepo::params::selinux: true
+    mrepo::params::rhn: true
+    mrepo::params::rhn_username: user
+    mrepo::params::rhn_password: pass
 
 Mirror multiple centos 5 repositories
 
-    mrepo::repo { "centos5-x86_64":
+    mrepo::repo { 'centos5-x86_64':
       ensure    => present,
-      update    => "nightly",
-      repotitle => "CentOS 5.6 64 bit",
-      arch      => "x86_64",
-      release   => "5.6",
+      update    => 'nightly',
+      repotitle => 'CentOS 5.6 64 bit',
+      arch      => 'x86_64',
+      release   => '5.6',
       urls      => {
         addons      => 'rsync://mirrors.kernel.org/centos/$release/addons/$arch/',
         centosplus  => 'rsync://mirrors.kernel.org/centos/$release/centosplus/$arch/',
@@ -34,12 +45,12 @@ Mirror multiple centos 5 repositories
       }
     }
 
-    mrepo::repo { "centos5-i386":
+    mrepo::repo { 'centos5-i386':
       ensure    => present,
-      update    => "nightly",
-      repotitle => "CentOS 5.6 64 bit",
-      arch      => "i386",
-      release   => "5.6",
+      update    => 'nightly',
+      repotitle => 'CentOS 5.6 64 bit',
+      arch      => 'i386',
+      release   => '5.6',
       urls      => {
         addons      => 'rsync://mirrors.kernel.org/centos/$release/addons/$arch/',
         centosplus  => 'rsync://mirrors.kernel.org/centos/$release/centosplus/$arch/',
@@ -49,22 +60,23 @@ Mirror multiple centos 5 repositories
 
 Mirror multiple rhel channels
 
-    mrepo::repo { "rhel6server-x86_64":
-      ensure     => present,
-      update     => "nightly",
-      repotitle  => 'Red Hat Enterprise Linux Server $release ($arch)',
-      rhn        => true,
-      arch       => "x86_64",
-      release    => "6",
-      rhnrelease => "6Server",
-      iso        => 'rhel-server-6.0-$arch-dvd.iso',
-      urls       => {
-        updates       => 'rhns:///rhel-$arch-server-6',
-        vt            => 'rhns:///rhel-$arch-server-vt-6',
-        supplementary => 'rhns:///rhel-$arch-server-supplementary-6',
-        fasttrack     => 'rhns:///rhel-$arch-server-fasttrack-6',
-        hts           => 'rhns:///rhel-$arch-server-hts-6',
-        rhn-tools     => 'rhns:///rhn-tools-rhel-$arch-server-6',
+    mrepo::repo { 'rhel6server-x86_64':
+      ensure      => present,
+      update      => 'nightly',
+      repotitle   => 'Red Hat Enterprise Linux Server $release ($arch)',
+      rhn         => true,
+      type        => 'rhn',
+      arch        => 'x86_64',
+      release     => '6',
+      typerelease => '6Server',
+      iso         => 'rhel-server-6.0-$arch-dvd.iso',
+      urls        => {
+        updates       => 'rhns:///rhel-$arch-server-$release',
+        vt            => 'rhns:///rhel-$arch-server-vt-$release',
+        supplementary => 'rhns:///rhel-$arch-server-supplementary-$release',
+        fasttrack     => 'rhns:///rhel-$arch-server-fasttrack-$release',
+        hts           => 'rhns:///rhel-$arch-server-hts-$release',
+        rhn-tools     => 'rhns:///rhn-tools-rhel-$arch-server-$release',
       }
     }
 
@@ -109,12 +121,12 @@ surround the string in single quotes so puppet doesn't try to expand them.
 
 So this:
 
-    mrepo::repo { "centos5-x86_64":
+    mrepo::repo { 'centos5-x86_64':
       ensure    => present,
-      update    => "nightly",
-      repotitle => "CentOS 5.6 64 bit",
-      arch      => "x86_64",
-      release   => "5.6",
+      update    => 'nightly',
+      repotitle => 'CentOS 5.6 64 bit',
+      arch      => 'x86_64',
+      release   => '5.6',
       urls      => {
         addons      => 'rsync://mirrors.kernel.org/centos/$release/$repo/$arch/',
         centosplus  => 'rsync://mirrors.kernel.org/centos/$release/$repo/$arch/',
@@ -124,12 +136,12 @@ So this:
 
 Is equivalent to this:
 
-    mrepo::repo { "centos5-x86_64":
+    mrepo::repo { 'centos5-x86_64':
       ensure    => present,
-      update    => "nightly",
-      repotitle => "CentOS 5.6 64 bit",
-      arch      => "x86_64",
-      release   => "5.6",
+      update    => 'nightly',
+      repotitle => 'CentOS 5.6 64 bit',
+      arch      => 'x86_64',
+      release   => '5.6',
         addons      => 'rsync://mirrors.kernel.org/centos/5.6/addons/x86_64/',
         centosplus  => 'rsync://mirrors.kernel.org/centos/5.6/centosplus/x86_64/',
         updates     => 'rsync://mirrors.kernel.org/centos/5.6/updates/x86_64/',

--- a/README.redhat.markdown
+++ b/README.redhat.markdown
@@ -10,6 +10,10 @@ fact. If you specify the rhn parameter to mrepo::repo as false, it will not
 attempt to generate a systemid and you can do that interactively with
 gensystemid after the mrepo module has been applied.
 
+For CentOS servers with the rhn parameter set as true, RHN dependencies
+will be configured by default. For RHEL servers, also specify the
+rhn_config parameter as true in order to configure the RHN dependencies.
+
 ## systemid and entitlements ##
 
 RHEL mirroring operates by emulating a specific RedHat release and
@@ -17,18 +21,19 @@ architecture, which will require at least one entitlement. You can also mirror
 additional channels, but be warned that they may require additional
 entitlements.
 
-### the rhnrelease parameter ###
+### the typerelease parameter ###
 
 Unfortunately there is no regular pattern for release names and available
 architectures.  Validation for this would get prohibitively costly, and has
 been left as the responsibility of the user. In addition, there is a common
 convention to mainly differentiate between releases on the major version
-number. The rhnrelease field was added to mrepo::repo to deal with this
+number. The type and typerelease fields were added to mrepo::repo to deal with this
 complexity. 
 
-The rhnrelease and architecture must match the following values in order for a
-valid systemid to be generated. This list was pulled from the gensystemid
-command, from mrepo release 8138e3bb6b5aa26cf8db.
+For RHN, $type must be 'rhn', $release is generally similar to '5.6' or '6',
+and $typerelease and $arch must match the following values in order for 
+a valid systemid to be generated.
+This list was pulled from the gensystemid command, from mrepo release 8138e3bb6b5aa26cf8db.
 
   * '6Workstation': 'i386', 'x86_64'
   * '6Server': 'i386', 'ppc', 's390', 's390x', 'x86_64'

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -24,29 +24,31 @@ class mrepo::package {
   $group  = $mrepo::params::group
   $source = $mrepo::params::source
   $proto  = $mrepo::params::git_proto
-
+  $ensure = $mrepo::params::ensure_src
   case $source {
     git: {
-      vcsrepo { "/usr/src/mrepo":
-        ensure    => latest,
-        revision  => 'HEAD',
-        provider  => "git",
-        source    => "${proto}://github.com/dagwieers/mrepo.git",
+      vcsrepo { '/usr/src/mrepo':
+        ensure   => $ensure,
+        revision => 'HEAD',
+        provider => 'git',
+        source   => "${proto}://github.com/dagwieers/mrepo.git",
       }
 
-      exec { "Install mrepo from source":
+      exec { 'Install mrepo from source':
         refreshonly => true,
-        path        => "/usr/bin:/usr/sbin:/sbin:/bin",
-        cwd         => "/usr/src/mrepo",
-        refresh     => "make install",
-        subscribe   => Vcsrepo["/usr/src/mrepo"],
-        logoutput => on_failure,
+        path        => '/usr/bin:/usr/sbin:/sbin:/bin',
+        cwd         => '/usr/src/mrepo',
+        refresh     => 'make install',
+        subscribe   => Vcsrepo['/usr/src/mrepo'],
+        logoutput   => on_failure,
       }
     }
     package: {
-      package { "mrepo":
+      package { 'mrepo':
         ensure  => present,
       }
+    }
+    default: {
     }
   }
 
@@ -60,21 +62,21 @@ class mrepo::package {
   $http_proxy   = $mrepo::params::http_proxy
   $https_proxy  = $mrepo::params::https_proxy
 
-  file { "/etc/mrepo.conf":
+  file { '/etc/mrepo.conf':
     ensure  => present,
     owner   => $user,
     group   => $group,
     mode    => '0640',
-    content => template("mrepo/mrepo.conf.erb"),
+    content => template('mrepo/mrepo.conf.erb'),
   }
 
   file {
-    "/etc/mrepo.conf.d":
+    '/etc/mrepo.conf.d':
       ensure  => directory,
       owner   => $user,
       group   => $group,
       mode    => '0755';
-    "/var/cache/mrepo":
+    '/var/cache/mrepo':
       ensure  => directory,
       owner   => $user,
       group   => $group,
@@ -84,7 +86,7 @@ class mrepo::package {
       owner   => $user,
       group   => $group,
       mode    => '0755';
-    "/var/log/mrepo.log":
+    '/var/log/mrepo.log':
       ensure  => file,
       owner   => $user,
       group   => $group,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -23,13 +23,26 @@
 # Default: package
 # Values: git, package
 #
+# [*ensure_src*]
+# Ensure value for the package source.
+# Note that with source set to 'git', setting ensure_src to 'latest'
+#  may cause module-removed source files (e.g. httpd mrepo.conf) to be restored
+# Default: latest
+# Values: latest, present, absent
+#
 # [*selinux*]
 # Whether to update the selinux context for the mrepo document root.
 # Default: the selinux fact.
 # Values: true, false
 #
 # [*rhn*]
-# Whether to install redhat dependencies or not. Defaults to false.
+# Whether to install RedHat dependencies or not. Defaults to false.
+# Default: false
+# Values: true, false
+#
+# [*rhn_config*]
+# Whether to install RedHat dependencies for RHN on RHEL. Defaults to false.
+# Note: Irrelevant (assumed true) for CentOS servers with rhn=true.
 # Default: false
 # Values: true, false
 #
@@ -38,6 +51,10 @@
 #
 # [*rhn_password*]
 # The Redhat Network password. Must be set if the param rhn is true.
+#
+# [*genid_command*]
+# The base command to use to generate a systemid for RHN (mrepo::repo::rhn).
+# Default: /usr/bin/gensystemid 
 #
 # [*mailto*]
 #
@@ -72,10 +89,13 @@ class mrepo::params (
   $user           = 'apache',
   $group          = 'apache',
   $source         = 'package',
+  $ensure_src     = 'latest',
   $selinux        = undef,
   $rhn            = false,
+  $rhn_config     = false,
   $rhn_username   = '',
   $rhn_password   = '',
+  $genid_command  = '/usr/bin/gensystemid',
   $mailto         = 'UNSET',
   $git_proto      = 'git',
   $descriptions   = {},

--- a/manifests/rhn.pp
+++ b/manifests/rhn.pp
@@ -21,68 +21,70 @@
 class mrepo::rhn {
 
   include mrepo::params
-  $group = $mrepo::params::group
+  $group        = $mrepo::params::group
+  $rhn          = $mrepo::params::rhn
+  $rhn_config   = $mrepo::params::rhn_config
 
-  if $mrepo::params::rhn == true {
+  if $rhn == true {
 
-    package { "pyOpenSSL":
+    package { 'pyOpenSSL':
       ensure  => present,
     }
 
     # CentOS does not have redhat network specific configuration files by default
-    if $operatingsystem == 'CentOS' {
+    if $::operatingsystem == 'CentOS' or $rhn_config == true {
 
       file {
-        "/etc/sysconfig/rhn":
-          ensure  => directory,
-          owner   => "root",
-          group   => "root",
-          mode    => "0755",
+        '/etc/sysconfig/rhn':
+          ensure => directory,
+          owner  => 'root',
+          group  => 'root',
+          mode   => '0755',
       }
-      exec { "Generate rhnuuid":
+      exec { 'Generate rhnuuid':
         command   => 'printf "rhnuuid=%s\n" `/usr/bin/uuidgen` >> /etc/sysconfig/rhn/up2date-uuid',
-        path      => [ "/usr/bin", "/bin" ],
-        user      => "root",
+        path      => [ '/usr/bin', '/bin' ],
+        user      => 'root',
         group     => $group,
-        creates   => "/etc/sysconfig/rhn/up2date-uuid",
+        creates   => '/etc/sysconfig/rhn/up2date-uuid',
         logoutput => on_failure,
         require   => File['/etc/sysconfig/rhn'],
       }
 
-      file { "/etc/sysconfig/rhn/up2date-uuid":
+      file { '/etc/sysconfig/rhn/up2date-uuid':
         ensure  => present,
         replace => false,
-        owner   => "root",
+        owner   => 'root',
         group   => $group,
-        mode    => "0640",
-        require => Exec["Generate rhnuuid"],
+        mode    => '0640',
+        require => Exec['Generate rhnuuid'],
       }
 
-      file { "/etc/sysconfig/rhn/sources":
+      file { '/etc/sysconfig/rhn/sources':
         ensure  => present,
-        owner   => "root",
-        group   => "root",
-        mode    => "0644",
-        content => "up2date default",
+        owner   => 'root',
+        group   => 'root',
+        mode    => '0644',
+        content => 'up2date default',
       }
 
-      file { "/usr/share/mrepo/rhn/RHNS-CA-CERT":
-        ensure  => present,
-        owner   => "root",
-        group   => "root",
-        mode    => "0644",
-        source  => "puppet:///modules/mrepo/RHNS-CA-CERT",
+      file { '/usr/share/mrepo/rhn/RHNS-CA-CERT':
+        ensure => present,
+        owner  => 'root',
+        group  => 'root',
+        mode   => '0644',
+        source => 'puppet:///modules/mrepo/RHNS-CA-CERT',
       }
 
       file {
-        "/usr/share/rhn":
+        '/usr/share/rhn':
           ensure  => directory,
-          owner   => "root",
-          group   => "root",
-          mode    => "0755";
-        "/usr/share/rhn/RHNS-CA-CERT":
+          owner   => 'root',
+          group   => 'root',
+          mode    => '0755';
+        '/usr/share/rhn/RHNS-CA-CERT':
           ensure  => link,
-          target  => "/usr/share/mrepo/rhn/RHNS-CA-CERT";
+          target  => '/usr/share/mrepo/rhn/RHNS-CA-CERT';
       }
     }
   }


### PR DESCRIPTION
- Add a rhn_config parameter for non-CentOS systems that need the RHN configurations in rhn.repo
 - Remove mention of rhnrelease (unused) in favor of typerelease
 - Set default of typerelease to $release in repo.pp (as described in comments)
 - Document using the type parameter for rhn repos
 - Set default http_proxy and https_proxy to ' ' to workaround bug http://projects.puppetlabs.com/issues/19848
 - Update README.redhat.markdown and README.markdown (including examples)
 - Clean up lint errors