### PR TITLE
Explicitly scope $mrepo::params::use_selinux

### DIFF
--- a/manifests/selinux.pp
+++ b/manifests/selinux.pp
@@ -25,7 +25,7 @@ class mrepo::selinux {
 
   $context = "system_u:object_r:httpd_sys_content_t"
 
-  if $use_selinux {
+  if $mrepo::params::use_selinux {
     exec { "Apply httpd context to mrepo $src_root":
       command   => "chcon -hR $context $src_root",
       path      => [ "/usr/bin", "/bin" ],


### PR DESCRIPTION
This variable reference looks like it would work under dynamic scoping, but currently the conditional will always fail as it cannot reference $use_selinux. Explicitly referencing the variable in the params class corrects this.