### PR TITLE
only include the `ip` parameter in the apache vhost if $ip_based is true

### DIFF
--- a/manifests/webservice.pp
+++ b/manifests/webservice.pp
@@ -44,7 +44,11 @@ class mrepo::webservice(
         docroot           => $docroot,
         custom_fragment   => template("${module_name}/apache.conf.erb"),
         ip_based          => $ip_based,
-        ip                => $ip,
+      }
+      if $ip_based {
+        Apache::Vhost['mrepo'] {
+          ip => $ip,
+        }
       }
     }
     absent: {


### PR DESCRIPTION
Assigning the `ip` parameter in the apache vhost resource when using the default apache configuration will fail, even if `ip_based` is false, because the apache module just looks at whether or not `ip` is assigned.  This PR makes it so the `ip` parameter only gets assigned when `ip_based` is true.