### PR TITLE
(maint) module does not unmount ISOs

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -268,7 +268,7 @@ define mrepo::repo (
       exec { "Unmount any mirrored ISOs for ${name}":
         command   => "umount ${www_root_subdir}/disc*",
         path      => ['/usr/bin', '/bin', '/usr/sbin', '/sbin'],
-        onlyif    => "mount | grep ${www_root_subdir}/disk",
+        onlyif    => "mount | grep ${www_root_subdir}/disc",
         provider  => shell,
         logoutput => true,
       }


### PR DESCRIPTION
The grep string does not match the mount point and does not unmount ISOs

Mounts
```
/srv/mrepo/iso/Fedora-14-i386-DVD.iso on /srv/mrepo/www/fedora14-i386/disc1 type iso9660 (ro,loop=/dev/loop152)
/srv/mrepo/iso/Fedora-20-i386-DVD.iso on /srv/mrepo/www/fedora20-i386/disc1 type iso9660 (ro,loop=/dev/loop153)
/srv/mrepo/iso/Fedora-20-x86_64-DVD.iso on /srv/mrepo/www/fedora20-x86_64/disc1 type iso9660 (ro,loop=/dev/loop154)
```

Updated grep
```
-bash-4.1$ mount | grep /srv/mrepo/www/fedora20-x86_64/disc
/srv/mrepo/iso/Fedora-20-x86_64-DVD.iso on /srv/mrepo/www/fedora20-x86_64/disc1 type iso9660 (ro,loop=/dev/loop154)
```
https://github.com/dagwieers/mrepo/blob/281872f7230fe0881e5b637db36192f0019df89f/mrepo#L585