### PR TITLE
Add mrpo rhnget options - RFC

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -54,13 +54,15 @@ class mrepo::package {
 
   # mrepo.conf template params
   #
-  $src_root     = $mrepo::params::src_root
-  $www_root     = $mrepo::params::www_root
-  $rhn_username = $mrepo::params::rhn_username
-  $rhn_password = $mrepo::params::rhn_password
-  $mailto       = $mrepo::params::mailto
-  $http_proxy   = $mrepo::params::http_proxy
-  $https_proxy  = $mrepo::params::https_proxy
+  $src_root            = $mrepo::params::src_root
+  $www_root            = $mrepo::params::www_root
+  $rhn_username        = $mrepo::params::rhn_username
+  $rhn_password        = $mrepo::params::rhn_password
+  $rhnget_cleanup      = $mrepo::params::rhnget_cleanup
+  $rhnget_download_all = $mrepo::params::rhnget_download_all
+  $mailto              = $mrepo::params::mailto
+  $http_proxy          = $mrepo::params::http_proxy
+  $https_proxy         = $mrepo::params::https_proxy
 
   file { '/etc/mrepo.conf':
     ensure  => present,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -60,6 +60,12 @@
 # [*rhn_password*]
 # The Redhat Network password. Must be set if the param rhn is true.
 #
+# [*rhnget_cleanup*]
+# Clean up packages that are not on the sending side? mrepo default yes.
+#
+# [*rhnget_download_all*]
+# Download older versions of packages? mrepo default no.
+#
 # [*genid_command*]
 # The base command to use to generate a systemid for RHN (mrepo::repo::rhn).
 # Default: /usr/bin/gensystemid 
@@ -91,28 +97,30 @@
 # Copyright 2011 Puppet Labs, unless otherwise noted
 #
 class mrepo::params (
-  $src_root       = '/var/mrepo',
-  $www_root       = '/var/www/mrepo',
-  $www_servername = 'mrepo',
-  $www_ip         = $::ipaddress,
-  $www_ip_based   = false,
-  $user           = 'apache',
-  $group          = 'apache',
-  $source         = 'package',
-  $ensure_src     = 'latest',
-  $selinux        = undef,
-  $rhn            = false,
-  $rhn_config     = false,
-  $rhn_username   = '',
-  $rhn_password   = '',
-  $genid_command  = '/usr/bin/gensystemid',
-  $mailto         = 'UNSET',
-  $git_proto      = 'git',
-  $descriptions   = {},
-  $http_proxy     = '',
-  $https_proxy    = '',
-  $priority       = '10',
-  $port           = '80',
+  $src_root            = '/var/mrepo',
+  $www_root            = '/var/www/mrepo',
+  $www_servername      = 'mrepo',
+  $www_ip              = $::ipaddress,
+  $www_ip_based        = false,
+  $user                = 'apache',
+  $group               = 'apache',
+  $source              = 'package',
+  $ensure_src          = 'latest',
+  $selinux             = undef,
+  $rhn                 = false,
+  $rhn_config          = false,
+  $rhn_username        = '',
+  $rhn_password        = '',
+  $rhnget_cleanup      = '',
+  $rhnget_download_all = '',
+  $genid_command       = '/usr/bin/gensystemid',
+  $mailto              = 'UNSET',
+  $git_proto           = 'git',
+  $descriptions        = {},
+  $http_proxy          = '',
+  $https_proxy         = '',
+  $priority            = '10',
+  $port                = '80',
 ) {
   validate_re($source, '^git$|^package$')
   validate_re($git_proto, '^git$|^https$')

--- a/templates/mrepo.conf.erb
+++ b/templates/mrepo.conf.erb
@@ -17,6 +17,12 @@ rhnlogin = <%= @rhn_username %>:<%= @rhn_password %>
 <% elsif not @rhn_username.empty? -%>
 rhnlogin = <%= @rhn_username %>
 <% end -%>
+<% if not @rhnget_cleanup.empty? -%>
+rhnget-cleanup = <%= @rhnget_cleanup =%>
+<% end -%>
+<% if not @rhnget_download_all.empty? -%>
+rhnget-download-all = <%= @rhnget_download_all =%>
+<% end -%>
 
 <% unless (mailto = @mailto) == 'UNSET' -%>
 mailto = <%= mailto %>


### PR DESCRIPTION
Add rhnget options to mrepo.conf
* rhnget_cleanup
* rhnget_download_all

For situations where older packages need to be available from cloned repositories.
